### PR TITLE
fix(local): support OpenAI-compatible servers and repair the clip pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,11 @@ MUAPI_API_KEY=your_muapi_key_here
 LLM_PROVIDER=openai           # openai or gemini
 OPENAI_API_KEY=your_openai_key_here
 OPENAI_MODEL=gpt-4o-mini
+# Optional: point at any OpenAI-compatible server to keep the ranking step
+# offline. Ollama example (OPENAI_API_KEY can then be left empty):
+#   OPENAI_BASE_URL=http://localhost:11434/v1
+#   OPENAI_MODEL=qwen3.6:latest
+OPENAI_BASE_URL=
 GEMINI_API_KEY=your_gemini_key_here
 GEMINI_MODEL=gemini-2.5-flash
 LOCAL_WHISPER_MODEL=base

--- a/requirements-local.txt
+++ b/requirements-local.txt
@@ -5,6 +5,8 @@ yt-dlp>=2024.1.1
 faster-whisper>=1.0.0
 openai>=1.0.0
 google-genai>=1.0.0
-opencv-python>=4.8.0
+# OpenCV 5.0 removed cv2.CascadeClassifier, which the auto-crop face
+# tracking depends on. Stay on 4.x until that path is ported.
+opencv-python>=4.8.0,<5
 # torch is only needed if you want CUDA Whisper. CPU works without it.
 # torch>=2.0

--- a/shorts_generator/config.py
+++ b/shorts_generator/config.py
@@ -13,6 +13,9 @@ POLL_TIMEOUT_SECONDS = float(os.getenv("MUAPI_POLL_TIMEOUT", "600"))
 # Local-mode (--mode local) settings — only consulted when running offline.
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "").strip()
 OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+# Point at any OpenAI-compatible server (Ollama, LM Studio, vLLM) to run the
+# ranking step fully offline. Empty means the real OpenAI API.
+OPENAI_BASE_URL = os.getenv("OPENAI_BASE_URL", "").strip()
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "").strip()
 GEMINI_MODEL = os.getenv("GEMINI_MODEL", "gemini-2.5-flash")
 LLM_PROVIDER = os.getenv("LLM_PROVIDER", "openai").strip().lower()
@@ -51,6 +54,10 @@ def require_api_key() -> str:
 
 def require_openai_key() -> str:
     if not OPENAI_API_KEY:
+        if OPENAI_BASE_URL:
+            # Self-hosted OpenAI-compatible servers ignore the key, but the
+            # client still requires a non-empty placeholder.
+            return "local"
         raise RuntimeError(
             "OPENAI_API_KEY is not set. Local mode needs an OpenAI key for highlight ranking. "
             "Add it to your .env or export it, or switch back to --mode api."

--- a/shorts_generator/local/clipper.py
+++ b/shorts_generator/local/clipper.py
@@ -72,39 +72,43 @@ def _reframe_vertical(in_path: str, out_path: str, aspect_ratio: str) -> str:
     fourcc = cv2.VideoWriter_fourcc(*"mp4v")
     writer = cv2.VideoWriter(silent_path, fourcc, fps, (crop_w, crop_h))
 
-    last_center: Optional[Tuple[int, int]] = None
-    smoothing = 0.15  # how aggressively to chase a new face position
-    while True:
-        ret, frame = cap.read()
-        if not ret:
-            break
+    # Always release the capture/writer: on Windows a leaked handle keeps the
+    # temp file locked, and the caller's cleanup then masks the real error.
+    try:
+        last_center: Optional[Tuple[int, int]] = None
+        smoothing = 0.15  # how aggressively to chase a new face position
+        while True:
+            ret, frame = cap.read()
+            if not ret:
+                break
 
-        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
-        faces = face_cascade.detectMultiScale(gray, scaleFactor=1.1, minNeighbors=5, minSize=(40, 40))
-        if len(faces) > 0:
-            # Pick the largest face — usually the speaker.
-            x, y, w, h = max(faces, key=lambda f: f[2] * f[3])
-            cx = x + w // 2
-            cy = y + h // 2
+            gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+            faces = face_cascade.detectMultiScale(gray, scaleFactor=1.1, minNeighbors=5, minSize=(40, 40))
+            if len(faces) > 0:
+                # Pick the largest face — usually the speaker.
+                x, y, w, h = max(faces, key=lambda f: f[2] * f[3])
+                cx = x + w // 2
+                cy = y + h // 2
+                if last_center is None:
+                    last_center = (cx, cy)
+                else:
+                    lx, ly = last_center
+                    last_center = (
+                        int(lx + (cx - lx) * smoothing),
+                        int(ly + (cy - ly) * smoothing),
+                    )
             if last_center is None:
-                last_center = (cx, cy)
-            else:
-                lx, ly = last_center
-                last_center = (
-                    int(lx + (cx - lx) * smoothing),
-                    int(ly + (cy - ly) * smoothing),
-                )
-        if last_center is None:
-            last_center = (src_w // 2, src_h // 2)
+                last_center = (src_w // 2, src_h // 2)
 
-        cx, cy = last_center
-        x0 = max(0, min(src_w - crop_w, cx - crop_w // 2))
-        y0 = max(0, min(src_h - crop_h, cy - crop_h // 2))
-        cropped = frame[y0:y0 + crop_h, x0:x0 + crop_w]
-        writer.write(cropped)
+            cx, cy = last_center
+            x0 = max(0, min(src_w - crop_w, cx - crop_w // 2))
+            y0 = max(0, min(src_h - crop_h, cy - crop_h // 2))
+            cropped = frame[y0:y0 + crop_h, x0:x0 + crop_w]
+            writer.write(cropped)
 
-    cap.release()
-    writer.release()
+    finally:
+        cap.release()
+        writer.release()
 
     # Mux audio from the cut clip back onto the silent reframed video.
     cmd = [
@@ -136,7 +140,11 @@ def crop_clip_local(
         _reframe_vertical(cut_path, out_path, aspect_ratio)
     finally:
         if os.path.exists(cut_path):
-            os.remove(cut_path)
+            try:
+                os.remove(cut_path)
+            except OSError:
+                # Never let cleanup mask the real failure above.
+                pass
     return out_path
 
 

--- a/shorts_generator/local/downloader.py
+++ b/shorts_generator/local/downloader.py
@@ -110,7 +110,7 @@ def download_youtube_local(video_url: str, fmt: str = "720", out_dir: Optional[s
             print(f"[download/local] reusing cached download: {cached}", flush=True)
             return cached
 
-    print(f"[download/local] {video_url} @ {fmt}p → {out_dir}/", flush=True)
+    print(f"[download/local] {video_url} @ {fmt}p -> {out_dir}/", flush=True)
     ydl_opts = {
         "format": _format_for(fmt),
         "outtmpl": os.path.join(out_dir, "source_%(id)s.%(ext)s"),
@@ -118,6 +118,11 @@ def download_youtube_local(video_url: str, fmt: str = "720", out_dir: Optional[s
         "quiet": True,
         "no_warnings": True,
         "noprogress": True,
+        # The default web client is served SABR-only streams that 403 on
+        # download; these clients still hand out plain progressive URLs.
+        "extractor_args": {
+            "youtube": {"player_client": ["android", "web_safari", "web"]}
+        },
     }
 
     with yt_dlp.YoutubeDL(ydl_opts) as ydl:

--- a/shorts_generator/local/llm.py
+++ b/shorts_generator/local/llm.py
@@ -1,6 +1,7 @@
 """Local LLM backend — OpenAI or Gemini, selected by LLM_PROVIDER."""
 from ..config import (
     GEMINI_MODEL,
+    OPENAI_BASE_URL,
     LLM_PROVIDER,
     OPENAI_MODEL,
     require_gemini_key,
@@ -18,7 +19,11 @@ def call_openai_llm(prompt: str) -> str:
             "    pip install -r requirements-local.txt"
         ) from e
 
-    client = OpenAI(api_key=require_openai_key())
+    client = OpenAI(
+        api_key=require_openai_key(),
+        base_url=OPENAI_BASE_URL or None,
+        timeout=600,
+    )
     response = client.chat.completions.create(
         model=OPENAI_MODEL,
         temperature=0.7,


### PR DESCRIPTION
## What

`--mode local` advertises offline operation, but on a clean install it could not produce a clip. Four independent issues, each of which alone is fatal:

**1. No way to use a local LLM.** `call_openai_llm()` built the client with no `base_url`, so `LLM_PROVIDER=openai` always reached `api.openai.com` — the "local" mode still required a paid key for the ranking step. Adds `OPENAI_BASE_URL`, so ranking can run against Ollama, LM Studio, vLLM, or any OpenAI-compatible server. `require_openai_key()` returns a placeholder when a custom base URL is set, since self-hosted servers ignore the key but the SDK rejects an empty one. Also adds a 600s timeout — local models are much slower to first token than the SDK default tolerates.

**2. yt-dlp 403 on every download.** YouTube serves the default web client SABR-only streams that fail to download. Pins the player clients to `android`/`web_safari`/`web`.

**3. OpenCV 5 breaks the auto-crop.** `requirements-local.txt` allowed `opencv-python>=4.8.0`, which now resolves to 5.0. That release removed `cv2.CascadeClassifier`, which the vertical reframe uses for face tracking, so every clip failed. Pinned to `<5`.

**4. An exception that hid issue 3.** `_reframe_vertical()` released its `VideoCapture`/`VideoWriter` only on the success path. When reframing raised, the handles leaked, Windows kept the temp file locked, and the caller's `os.remove()` in a `finally` raised `WinError 32` — replacing the original traceback. The user saw a file-lock error instead of the real cause. Now releases in a `finally` and lets temp cleanup fail quietly.

Also replaces a `U+2192` arrow in a progress `print()` that raised `UnicodeEncodeError` under the Windows cp1252 console.

## Why it matters

Issues 2 and 3 are time bombs from upstream drift rather than original bugs — they'd hit anyone doing a fresh `pip install -r requirements-local.txt` today. Issue 4 is what makes them expensive: it converts any reframe failure into a misleading error message, so the real cause isn't visible without patching the source.

## Verification

Ran end-to-end on Windows 11 / Python 3.10 / RTX 5090:

- YouTube download via yt-dlp
- transcription with `faster-whisper` `large-v3` on CUDA
- highlight ranking through Ollama (`qwen3.6`), no cloud calls
- output: 3× 9:16 mp4 (202×360) with muxed AAC audio, correct durations

The existing `_parse_json_loose()` handled the local model's output without changes.

## Notes for reviewers

- Fully backward compatible. `OPENAI_BASE_URL` is unset by default, which preserves the exact current OpenAI behavior; the Gemini path is untouched.
- The OpenCV pin is a stopgap. The real fix is porting face detection off Haar cascades — happy to do that separately if you'd prefer.
- Source video currently downloads at 360p regardless of `--format`: YouTube gates 720p+ behind a PO token, and `tv_embedded` lists those formats but 403s on fetch. Not addressed here, since the fix involves cookie-based auth and is a larger decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
