### PR TITLE
feat: add OrcaRouter as an LLM_PROVIDER option for local mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,11 @@
 MUAPI_API_KEY=your_muapi_key_here
 
 # Local mode (--mode local)
-LLM_PROVIDER=openai           # openai or gemini
+LLM_PROVIDER=openai           # openai, orcarouter, or gemini
 OPENAI_API_KEY=your_openai_key_here
 OPENAI_MODEL=gpt-4o-mini
+ORCAROUTER_API_KEY=your_orcarouter_key_here
+ORCAROUTER_MODEL=openai/gpt-4o-mini      # optional, default openai/gpt-4o-mini
 GEMINI_API_KEY=your_gemini_key_here
 GEMINI_MODEL=gemini-2.5-flash
 LOCAL_WHISPER_MODEL=base

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Built for creators, agencies, and developers who don't want to pay $20–$300/mo
 ## Features
 
 - **🎬 YouTube In, Vertical Out**: Hand it any YouTube URL — get back N viral-ready 9:16 mp4s
-- **🔀 Two Modes — API (fast) or Local (offline)**: Default `--mode api` uses MuAPI for download/transcription/cropping; `--mode local` runs entirely on your machine with `yt-dlp`, `faster-whisper`, and `ffmpeg`/`opencv`, and lets you pick OpenAI or Gemini for highlight ranking
+- **🔀 Two Modes — API (fast) or Local (offline)**: Default `--mode api` uses MuAPI for download/transcription/cropping; `--mode local` runs entirely on your machine with `yt-dlp`, `faster-whisper`, and `ffmpeg`/`opencv`, and lets you pick OpenAI, OrcaRouter, or Gemini for highlight ranking
 - **🤖 Virality-Aware Highlight Selection**: Clips ranked on hooks, emotional peaks, opinion bombs, revelation moments, conflict, quotable lines, story peaks, and practical value — not just generic "interesting"
 - **📈 Score + Hook + Reason for Every Clip**: Each highlight comes with a viral score, an opening hook line, and a one-sentence explanation of why it works
 - **🎤 Whisper Transcription, Your Choice**: Cloud (`/openai-whisper` via MuAPI) or local (`faster-whisper`, CPU or CUDA) — same downstream output shape
@@ -64,7 +64,7 @@ Don't want to self-host? The [AI Clipping API](https://muapi.ai/playground/ai-cl
 
 - Python 3.10+
 - For **API mode (default)**: a MuAPI key — powers download, transcription, highlight ranking, and clipping in a single dependency
-- For **Local mode** (`--mode local`): `ffmpeg` on your PATH and an LLM API key (`OPENAI_API_KEY` or `GEMINI_API_KEY`; only the LLM step is remote)
+- For **Local mode** (`--mode local`): `ffmpeg` on your PATH and an LLM API key (`OPENAI_API_KEY`, `ORCAROUTER_API_KEY`, or `GEMINI_API_KEY`; only the LLM step is remote)
 
 ### Steps
 
@@ -95,9 +95,11 @@ Don't want to self-host? The [AI Clipping API](https://muapi.ai/playground/ai-cl
    MUAPI_API_KEY=your_muapi_key_here
 
    # Local mode (--mode local)
-   LLM_PROVIDER=openai         # openai or gemini
+   LLM_PROVIDER=openai         # openai, orcarouter, or gemini
    OPENAI_API_KEY=your_openai_key_here
    OPENAI_MODEL=gpt-4o-mini          # optional, default gpt-4o-mini
+   ORCAROUTER_API_KEY=your_orcarouter_key_here
+   ORCAROUTER_MODEL=openai/gpt-4o-mini      # optional, default openai/gpt-4o-mini
    GEMINI_API_KEY=your_gemini_key_here
    GEMINI_MODEL=gemini-2.5-flash      # optional, default gemini-2.5-flash
    LOCAL_WHISPER_MODEL=base          # tiny / base / small / medium / large-v3
@@ -188,10 +190,10 @@ xargs -a urls.txt -I{} python main.py "{}"
 |---|---|---|
 | Download | MuAPI `/youtube-download` | `yt-dlp` for remote URLs, direct file path for local inputs |
 | Transcription | MuAPI `/openai-whisper` | `faster-whisper` (CPU or CUDA) |
-| Highlight LLM | MuAPI `gpt-5-mini` | `LLM_PROVIDER=openai` uses OpenAI (`gpt-4o-mini` by default), `LLM_PROVIDER=gemini` uses Gemini (`gemini-2.5-flash` by default) |
+| Highlight LLM | MuAPI `gpt-5-mini` | `LLM_PROVIDER=openai` uses OpenAI (`gpt-4o-mini` by default), `LLM_PROVIDER=orcarouter` uses OrcaRouter (`openai/gpt-4o-mini` by default), `LLM_PROVIDER=gemini` uses Gemini (`gemini-2.5-flash` by default) |
 | Vertical crop | MuAPI `/autocrop` | `ffmpeg` + OpenCV face tracking |
 | Output | hosted URLs | local mp4 paths |
-| Required keys | `MUAPI_API_KEY` | `OPENAI_API_KEY` or `GEMINI_API_KEY` (+ `ffmpeg` on PATH) |
+| Required keys | `MUAPI_API_KEY` | `OPENAI_API_KEY`, `ORCAROUTER_API_KEY`, or `GEMINI_API_KEY` (+ `ffmpeg` on PATH) |
 
 ## How It Works
 
@@ -281,7 +283,7 @@ AI-Youtube-Shorts-Generator/
     └── local/                    --mode local backends (offline)
         ├── downloader.py         yt-dlp download
         ├── transcriber.py        faster-whisper transcription
-        ├── llm.py                OpenAI or Gemini client selector
+        ├── llm.py                OpenAI, OrcaRouter, or Gemini client selector
         └── clipper.py            ffmpeg cut + OpenCV vertical crop
 ```
 

--- a/shorts_generator/config.py
+++ b/shorts_generator/config.py
@@ -15,6 +15,8 @@ OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "").strip()
 OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "").strip()
 GEMINI_MODEL = os.getenv("GEMINI_MODEL", "gemini-2.5-flash")
+ORCAROUTER_API_KEY = os.getenv("ORCAROUTER_API_KEY", "").strip()
+ORCAROUTER_MODEL = os.getenv("ORCAROUTER_MODEL", "openai/gpt-4o-mini")
 LLM_PROVIDER = os.getenv("LLM_PROVIDER", "openai").strip().lower()
 LOCAL_WHISPER_MODEL = os.getenv("LOCAL_WHISPER_MODEL", "base")
 LOCAL_WHISPER_DEVICE = os.getenv("LOCAL_WHISPER_DEVICE", "auto")  # auto / cpu / cuda
@@ -65,3 +67,13 @@ def require_gemini_key() -> str:
             "Add it to your .env or export it, or switch LLM_PROVIDER back to openai."
         )
     return GEMINI_API_KEY
+
+
+def require_orcarouter_key() -> str:
+    if not ORCAROUTER_API_KEY:
+        raise RuntimeError(
+            "ORCAROUTER_API_KEY is not set. Local mode needs an OrcaRouter key when "
+            "LLM_PROVIDER=orcarouter. Add it to your .env or export it, or switch "
+            "LLM_PROVIDER back to openai."
+        )
+    return ORCAROUTER_API_KEY

--- a/shorts_generator/local/llm.py
+++ b/shorts_generator/local/llm.py
@@ -1,10 +1,12 @@
-"""Local LLM backend — OpenAI or Gemini, selected by LLM_PROVIDER."""
+"""Local LLM backend — OpenAI, OrcaRouter, or Gemini, selected by LLM_PROVIDER."""
 from ..config import (
     GEMINI_MODEL,
     LLM_PROVIDER,
     OPENAI_MODEL,
+    ORCAROUTER_MODEL,
     require_gemini_key,
     require_openai_key,
+    require_orcarouter_key,
 )
 
 
@@ -21,6 +23,33 @@ def call_openai_llm(prompt: str) -> str:
     client = OpenAI(api_key=require_openai_key())
     response = client.chat.completions.create(
         model=OPENAI_MODEL,
+        temperature=0.7,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response.choices[0].message.content or ""
+
+
+def call_orcarouter_llm(prompt: str) -> str:
+    """OrcaRouter backend used by --mode local when LLM_PROVIDER=orcarouter.
+
+    OrcaRouter (https://www.orcarouter.ai) is an OpenAI-compatible model-routing
+    gateway; we reuse the OpenAI SDK pointed at its endpoint, mirroring the
+    openai backend.
+    """
+    try:
+        from openai import OpenAI  # type: ignore
+    except ImportError as e:
+        raise RuntimeError(
+            "openai is required for LLM_PROVIDER=orcarouter. Install it with:\n"
+            "    pip install -r requirements-local.txt"
+        ) from e
+
+    client = OpenAI(
+        api_key=require_orcarouter_key(),
+        base_url="https://api.orcarouter.ai/v1",
+    )
+    response = client.chat.completions.create(
+        model=ORCAROUTER_MODEL,
         temperature=0.7,
         messages=[{"role": "user", "content": prompt}],
     )
@@ -55,8 +84,10 @@ def call_local_llm(prompt: str) -> str:
     provider = (LLM_PROVIDER or "openai").strip().lower()
     if provider == "openai":
         return call_openai_llm(prompt)
+    if provider == "orcarouter":
+        return call_orcarouter_llm(prompt)
     if provider == "gemini":
         return call_gemini_llm(prompt)
     raise RuntimeError(
-        f"Unknown LLM_PROVIDER={provider!r}. Use 'openai' or 'gemini'."
+        f"Unknown LLM_PROVIDER={provider!r}. Use 'openai', 'orcarouter', or 'gemini'."
     )


### PR DESCRIPTION
## Add OrcaRouter as an `LLM_PROVIDER` option for `--mode local`

This adds a named **orcarouter** provider to the local-mode highlight-ranking LLM, mirroring the existing `openai` path. [OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model-routing gateway, so this reuses the OpenAI SDK pointed at its endpoint (`https://api.orcarouter.ai/v1`) — no new dependencies.

### Changes
- `shorts_generator/config.py`: new `ORCAROUTER_API_KEY` / `ORCAROUTER_MODEL` settings and a `require_orcarouter_key()` guard, consistent with the existing key guards.
- `shorts_generator/local/llm.py`: new `call_orcarouter_llm()` backend and dispatch when `LLM_PROVIDER=orcarouter`.
- `.env.example` and `README.md`: document the new provider alongside OpenAI and Gemini.

### Why OrcaRouter
OrcaRouter is an OpenAI-compatible gateway that aggregates 200+ models under one endpoint and key, so users get the same local mode with a single `ORCAROUTER_API_KEY` and can switch models (e.g. `openai/gpt-4o-mini`, `anthropic/claude-sonnet-4-5`, `orcarouter/auto`) by changing one env var. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

### Usage
```bash
LLM_PROVIDER=orcarouter \
ORCAROUTER_API_KEY=sk-orca-... \
python main.py "https://www.youtube.com/watch?v=VIDEO_ID" --mode local
```

Defaults to `openai/gpt-4o-mini` when `ORCAROUTER_MODEL` is unset.

I'm an engineer on the OrcaRouter team.
