### PR TITLE
feat: add OrcaRouter as a named LLM provider for local mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,11 +2,14 @@
 MUAPI_API_KEY=your_muapi_key_here
 
 # Local mode (--mode local)
-LLM_PROVIDER=openai           # openai or gemini
+LLM_PROVIDER=openai           # openai, gemini, or orcarouter
 OPENAI_API_KEY=your_openai_key_here
 OPENAI_MODEL=gpt-4o-mini
 GEMINI_API_KEY=your_gemini_key_here
 GEMINI_MODEL=gemini-2.5-flash
+ORCAROUTER_API_KEY=sk-orca-your_orcarouter_key_here
+ORCAROUTER_MODEL=orcarouter/auto
+ORCAROUTER_API_BASE_URL=https://api.orcarouter.ai/v1
 LOCAL_WHISPER_MODEL=base
 LOCAL_WHISPER_DEVICE=auto
 LOCAL_OUTPUT_DIR=output

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Don't want to self-host? The [AI Clipping API](https://muapi.ai/playground/ai-cl
 
 - Python 3.10+
 - For **API mode (default)**: a MuAPI key — powers download, transcription, highlight ranking, and clipping in a single dependency
-- For **Local mode** (`--mode local`): `ffmpeg` on your PATH and an LLM API key (`OPENAI_API_KEY` or `GEMINI_API_KEY`; only the LLM step is remote)
+- For **Local mode** (`--mode local`): `ffmpeg` on your PATH and an LLM API key (`OPENAI_API_KEY`, `GEMINI_API_KEY`, or `ORCAROUTER_API_KEY`; only the LLM step is remote)
 
 ### Steps
 
@@ -95,11 +95,13 @@ Don't want to self-host? The [AI Clipping API](https://muapi.ai/playground/ai-cl
    MUAPI_API_KEY=your_muapi_key_here
 
    # Local mode (--mode local)
-   LLM_PROVIDER=openai         # openai or gemini
+   LLM_PROVIDER=openai         # openai, gemini, or orcarouter
    OPENAI_API_KEY=your_openai_key_here
    OPENAI_MODEL=gpt-4o-mini          # optional, default gpt-4o-mini
    GEMINI_API_KEY=your_gemini_key_here
    GEMINI_MODEL=gemini-2.5-flash      # optional, default gemini-2.5-flash
+   ORCAROUTER_API_KEY=your_orcarouter_key_here
+   ORCAROUTER_MODEL=orcarouter/auto   # optional, default orcarouter/auto
    LOCAL_WHISPER_MODEL=base          # tiny / base / small / medium / large-v3
    LOCAL_WHISPER_DEVICE=auto         # auto / cpu / cuda
    LOCAL_OUTPUT_DIR=output           # where local mp4s land
@@ -188,10 +190,10 @@ xargs -a urls.txt -I{} python main.py "{}"
 |---|---|---|
 | Download | MuAPI `/youtube-download` | `yt-dlp` for remote URLs, direct file path for local inputs |
 | Transcription | MuAPI `/openai-whisper` | `faster-whisper` (CPU or CUDA) |
-| Highlight LLM | MuAPI `gpt-5-mini` | `LLM_PROVIDER=openai` uses OpenAI (`gpt-4o-mini` by default), `LLM_PROVIDER=gemini` uses Gemini (`gemini-2.5-flash` by default) |
+| Highlight LLM | MuAPI `gpt-5-mini` | `LLM_PROVIDER=openai` uses OpenAI (`gpt-4o-mini` by default), `LLM_PROVIDER=gemini` uses Gemini (`gemini-2.5-flash` by default), `LLM_PROVIDER=orcarouter` uses OrcaRouter (`orcarouter/auto` by default) |
 | Vertical crop | MuAPI `/autocrop` | `ffmpeg` + OpenCV face tracking |
 | Output | hosted URLs | local mp4 paths |
-| Required keys | `MUAPI_API_KEY` | `OPENAI_API_KEY` or `GEMINI_API_KEY` (+ `ffmpeg` on PATH) |
+| Required keys | `MUAPI_API_KEY` | `OPENAI_API_KEY`, `GEMINI_API_KEY`, or `ORCAROUTER_API_KEY` (+ `ffmpeg` on PATH) |
 
 ## How It Works
 
@@ -281,7 +283,7 @@ AI-Youtube-Shorts-Generator/
     └── local/                    --mode local backends (offline)
         ├── downloader.py         yt-dlp download
         ├── transcriber.py        faster-whisper transcription
-        ├── llm.py                OpenAI or Gemini client selector
+        ├── llm.py                OpenAI, Gemini, or OrcaRouter client selector
         └── clipper.py            ffmpeg cut + OpenCV vertical crop
 ```
 

--- a/shorts_generator/config.py
+++ b/shorts_generator/config.py
@@ -15,6 +15,9 @@ OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "").strip()
 OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "").strip()
 GEMINI_MODEL = os.getenv("GEMINI_MODEL", "gemini-2.5-flash")
+ORCAROUTER_API_KEY = os.getenv("ORCAROUTER_API_KEY", "").strip()
+ORCAROUTER_MODEL = os.getenv("ORCAROUTER_MODEL", "orcarouter/auto")
+ORCAROUTER_API_BASE_URL = os.getenv("ORCAROUTER_API_BASE_URL", "https://api.orcarouter.ai/v1").rstrip("/")
 LLM_PROVIDER = os.getenv("LLM_PROVIDER", "openai").strip().lower()
 LOCAL_WHISPER_MODEL = os.getenv("LOCAL_WHISPER_MODEL", "base")
 LOCAL_WHISPER_DEVICE = os.getenv("LOCAL_WHISPER_DEVICE", "auto")  # auto / cpu / cuda
@@ -65,3 +68,13 @@ def require_gemini_key() -> str:
             "Add it to your .env or export it, or switch LLM_PROVIDER back to openai."
         )
     return GEMINI_API_KEY
+
+
+def require_orcarouter_key() -> str:
+    if not ORCAROUTER_API_KEY:
+        raise RuntimeError(
+            "ORCAROUTER_API_KEY is not set. Local mode needs an OrcaRouter key when "
+            "LLM_PROVIDER=orcarouter. Add it to your .env or export it, or switch "
+            "LLM_PROVIDER back to openai."
+        )
+    return ORCAROUTER_API_KEY

--- a/shorts_generator/local/llm.py
+++ b/shorts_generator/local/llm.py
@@ -1,10 +1,13 @@
-"""Local LLM backend — OpenAI or Gemini, selected by LLM_PROVIDER."""
+"""Local LLM backend — OpenAI, Gemini, or OrcaRouter, selected by LLM_PROVIDER."""
 from ..config import (
     GEMINI_MODEL,
     LLM_PROVIDER,
     OPENAI_MODEL,
+    ORCAROUTER_API_BASE_URL,
+    ORCAROUTER_MODEL,
     require_gemini_key,
     require_openai_key,
+    require_orcarouter_key,
 )
 
 
@@ -50,6 +53,32 @@ def call_gemini_llm(prompt: str) -> str:
     return response.text or ""
 
 
+def call_orcarouter_llm(prompt: str) -> str:
+    """OrcaRouter backend used by --mode local when LLM_PROVIDER=orcarouter.
+
+    OrcaRouter is an OpenAI-compatible gateway, so it reuses the OpenAI SDK with
+    a custom base URL and model namespace (e.g. ``orcarouter/auto``).
+    """
+    try:
+        from openai import OpenAI  # type: ignore
+    except ImportError as e:
+        raise RuntimeError(
+            "openai is required for LLM_PROVIDER=orcarouter. Install it with:\n"
+            "    pip install -r requirements-local.txt"
+        ) from e
+
+    client = OpenAI(
+        api_key=require_orcarouter_key(),
+        base_url=ORCAROUTER_API_BASE_URL,
+    )
+    response = client.chat.completions.create(
+        model=ORCAROUTER_MODEL,
+        temperature=0.7,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response.choices[0].message.content or ""
+
+
 def call_local_llm(prompt: str) -> str:
     """Dispatch to the configured local LLM provider."""
     provider = (LLM_PROVIDER or "openai").strip().lower()
@@ -57,6 +86,8 @@ def call_local_llm(prompt: str) -> str:
         return call_openai_llm(prompt)
     if provider == "gemini":
         return call_gemini_llm(prompt)
+    if provider == "orcarouter":
+        return call_orcarouter_llm(prompt)
     raise RuntimeError(
-        f"Unknown LLM_PROVIDER={provider!r}. Use 'openai' or 'gemini'."
+        f"Unknown LLM_PROVIDER={provider!r}. Use 'openai', 'gemini', or 'orcarouter'."
     )


### PR DESCRIPTION
## Add OrcaRouter as a named LLM provider for `--mode local`

This project's local mode already lets you pick a highlight-ranking LLM via `LLM_PROVIDER` — OpenAI (`openai`) or Gemini (`gemini`). This PR adds OrcaRouter as a first-class third option (`orcarouter`), mirroring the existing OpenAI backend exactly.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

### Changes

- **`shorts_generator/config.py`**: new `ORCAROUTER_API_KEY`, `ORCAROUTER_MODEL` (default `orcarouter/auto`), `ORCAROUTER_API_BASE_URL` (default `https://api.orcarouter.ai/v1`) env vars, plus a `require_orcarouter_key()` guard mirroring the OpenAI/Gemini ones.
- **`shorts_generator/local/llm.py`**: new `call_orcarouter_llm()` — an OpenAI Chat Completions call against the OrcaRouter base URL — wired into `call_local_llm()` alongside the existing `openai`/`gemini` dispatch.
- **`README.md` / `.env.example`**: document the new provider and env vars in the same spots where OpenAI/Gemini are described.

No changes to the API-mode MuAPI path; this only extends the `--mode local` LLM selector.

### Verification

- `python -m py_compile` clean on all touched modules; full package imports OK.
- L3 live test: ran `call_orcarouter_llm()` and the `LLM_PROVIDER=orcarouter` dispatch against the real API with a valid key — both returned a `200` JSON response (`{"ok": true, "provider": "orcarouter"}`).
- Missing-key path raises the expected `ORCAROUTER_API_KEY is not set` error.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team. Questions or a preferred model default — happy to adjust.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
