### PR TITLE
Fix --mode local: chunk timestamps dropped, unplayable mp4v output, crash on cropping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ venv/
 output/
 *.mp4
 .DS_Store
+result.json

--- a/recrop_from_result.py
+++ b/recrop_from_result.py
@@ -1,0 +1,26 @@
+import json
+import sys
+sys.path.insert(0, ".")
+from shorts_generator.local.clipper import crop_highlights_local
+
+with open("result.json") as f:
+    result = json.load(f)
+
+source_path = result["source_video_url"]
+top = sorted(result["highlights"], key=lambda h: int(h.get("score", 0)), reverse=True)[:10]
+
+print(f"Re-cropping {len(top)} clips from cached highlights (no new Gemini calls)")
+shorts = crop_highlights_local(source_path, top, aspect_ratio="9:16")
+
+result["shorts"] = shorts
+with open("result.json", "w") as f:
+    json.dump(result, f, indent=2)
+
+print("\n" + "=" * 72)
+for i, s in enumerate(shorts, 1):
+    print(f"\n#{i}  score={s.get('score')}  {s.get('start_time'):.1f}s -> {s.get('end_time'):.1f}s")
+    print(f"     title:  {s.get('title')}")
+    if s.get("clip_url"):
+        print(f"     clip:   {s['clip_url']}")
+    else:
+        print(f"     clip:   FAILED ({s.get('error')})")

--- a/requirements-local.txt
+++ b/requirements-local.txt
@@ -5,6 +5,6 @@ yt-dlp>=2024.1.1
 faster-whisper>=1.0.0
 openai>=1.0.0
 google-genai>=1.0.0
-opencv-python>=4.8.0
+opencv-python>=4.8.0,<5  # 5.x dropped cv2.CascadeClassifier, which crop_clip_local needs
 # torch is only needed if you want CUDA Whisper. CPU works without it.
 # torch>=2.0

--- a/shorts_generator/highlights.py
+++ b/shorts_generator/highlights.py
@@ -204,12 +204,17 @@ def call_highlight_api(
     num_clips: int,
     is_chunk: bool = False,
     llm_fn: LLMFn = call_muapi_llm,
+    max_end: Optional[float] = None,
 ) -> Dict:
     # Ask for ~2× the user's target so dedupe has headroom, but cap so the model
     # doesn't have to generate a huge JSON payload (which times out gpt-5-mini).
     target = max(num_clips * 2, 5)
     natural_max = max(2 if is_chunk else 3, int(duration / 90))
     min_clips = min(target, natural_max, 8)
+    # Segments in the transcript keep absolute (video-wide) timestamps even
+    # inside a chunk, and the model mirrors those back — so the valid range
+    # for a chunk is [offset, offset + duration], not [0, duration].
+    max_end = max_end if max_end is not None else duration
     system = HIGHLIGHT_SYSTEM_PROMPT.format(
         virality_criteria=VIRALITY_CRITERIA,
         content_type=content_info.get("content_type", "other"),
@@ -224,7 +229,7 @@ def call_highlight_api(
         raw = llm_fn(prompt)
         try:
             parsed = _parse_json_loose(raw)
-            highlights = _sanitize_highlights(parsed.get("highlights"), duration=duration)
+            highlights = _sanitize_highlights(parsed.get("highlights"), duration=max_end)
             if highlights:
                 return {"highlights": highlights}
             last_error = "no valid highlights in response"
@@ -292,11 +297,13 @@ def get_highlights(
             offset = chunk.get("_offset", 0)
             text = build_transcript_text(chunk)
             print(f"[highlights] chunk {i + 1}/{len(chunks)} (offset {offset:.0f}s)", flush=True)
-            result = call_highlight_api(text, content_info, chunk["duration"], num_clips=num_clips, is_chunk=True, llm_fn=llm_fn)
-            for h in result.get("highlights", []):
-                h["start_time"] = float(h["start_time"]) + offset
-                h["end_time"] = float(h["end_time"]) + offset
-                all_highlights.append(h)
+            result = call_highlight_api(
+                text, content_info, chunk["duration"], num_clips=num_clips,
+                is_chunk=True, llm_fn=llm_fn, max_end=offset + chunk["duration"],
+            )
+            # Timestamps in transcript_text (and thus in the model's reply)
+            # are already absolute video-wide times — no offset to re-add.
+            all_highlights.extend(result.get("highlights", []))
         highlights = dedupe_highlights(all_highlights)
     else:
         text = build_transcript_text(transcript)

--- a/shorts_generator/local/clipper.py
+++ b/shorts_generator/local/clipper.py
@@ -10,6 +10,8 @@ import os
 import subprocess
 from typing import Dict, List, Optional, Tuple
 
+import numpy as np
+
 from ..config import LOCAL_OUTPUT_DIR
 
 
@@ -26,9 +28,9 @@ def _cut_subclip(source_path: str, start: float, end: float, out_path: str) -> s
     """ffmpeg -ss start -to end → re-encoded mp4 with audio."""
     cmd = [
         "ffmpeg", "-y", "-loglevel", "error",
-        "-i", source_path,
         "-ss", f"{start:.3f}",
         "-to", f"{end:.3f}",
+        "-i", source_path,
         "-c:v", "libx264", "-preset", "fast", "-crf", "20",
         "-c:a", "aac", "-b:a", "128k",
         out_path,
@@ -74,44 +76,58 @@ def _reframe_vertical(in_path: str, out_path: str, aspect_ratio: str) -> str:
 
     last_center: Optional[Tuple[int, int]] = None
     smoothing = 0.15  # how aggressively to chase a new face position
+    # Haar detection on a full 4K frame is the bottleneck. Faces don't jump
+    # frame to frame, so detect on a downscaled frame and only every Nth
+    # frame — the smoothing above already hides the coarser cadence.
+    detect_every = 5
+    detect_scale = 0.25
+    frame_idx = 0
     while True:
         ret, frame = cap.read()
         if not ret:
             break
+        frame_idx += 1
 
-        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
-        faces = face_cascade.detectMultiScale(gray, scaleFactor=1.1, minNeighbors=5, minSize=(40, 40))
-        if len(faces) > 0:
-            # Pick the largest face — usually the speaker.
-            x, y, w, h = max(faces, key=lambda f: f[2] * f[3])
-            cx = x + w // 2
-            cy = y + h // 2
-            if last_center is None:
-                last_center = (cx, cy)
-            else:
-                lx, ly = last_center
-                last_center = (
-                    int(lx + (cx - lx) * smoothing),
-                    int(ly + (cy - ly) * smoothing),
-                )
+        if frame_idx % detect_every == 1:
+            small = cv2.resize(frame, None, fx=detect_scale, fy=detect_scale, interpolation=cv2.INTER_LINEAR)
+            gray = cv2.cvtColor(small, cv2.COLOR_BGR2GRAY)
+            faces = face_cascade.detectMultiScale(gray, scaleFactor=1.1, minNeighbors=5, minSize=(40, 40))
+            if len(faces) > 0:
+                # Pick the largest face — usually the speaker.
+                x, y, w, h = max(faces, key=lambda f: f[2] * f[3])
+                cx = int((x + w // 2) / detect_scale)
+                cy = int((y + h // 2) / detect_scale)
+                if last_center is None:
+                    last_center = (cx, cy)
+                else:
+                    lx, ly = last_center
+                    last_center = (
+                        int(lx + (cx - lx) * smoothing),
+                        int(ly + (cy - ly) * smoothing),
+                    )
         if last_center is None:
             last_center = (src_w // 2, src_h // 2)
 
         cx, cy = last_center
         x0 = max(0, min(src_w - crop_w, cx - crop_w // 2))
         y0 = max(0, min(src_h - crop_h, cy - crop_h // 2))
-        cropped = frame[y0:y0 + crop_h, x0:x0 + crop_w]
+        # .write() needs a C-contiguous array; a plain slice is a strided
+        # view and can corrupt memory / crash a few dozen frames in.
+        cropped = np.ascontiguousarray(frame[y0:y0 + crop_h, x0:x0 + crop_w])
         writer.write(cropped)
 
     cap.release()
     writer.release()
 
     # Mux audio from the cut clip back onto the silent reframed video.
+    # cv2.VideoWriter's "mp4v" fourcc is old-style MPEG-4 Part 2, which most
+    # players (Telegram included) won't render inline — re-encode to H.264
+    # here rather than "-c:v copy"-ing the raw mp4v stream through.
     cmd = [
         "ffmpeg", "-y", "-loglevel", "error",
         "-i", silent_path,
         "-i", in_path,
-        "-c:v", "copy",
+        "-c:v", "libx264", "-preset", "fast", "-crf", "20",
         "-c:a", "aac", "-b:a", "128k",
         "-map", "0:v:0", "-map", "1:a:0?",
         "-shortest",

--- a/shorts_generator/local/llm.py
+++ b/shorts_generator/local/llm.py
@@ -44,7 +44,7 @@ def call_gemini_llm(prompt: str) -> str:
         config={
             "temperature": 0.2,
             "response_mime_type": "application/json",
-            "max_output_tokens": 8192,
+            "max_output_tokens": 24576,
         },
     )
     return response.text or ""


### PR DESCRIPTION
I've been using `--mode local` (Gemini) to clip long videos, and hit three real bugs on a ~46min source with 10 output clips.

**1. Highlights from any chunk after the first one got silently dropped.**
For videos over 30 min, the transcript gets split into chunks, but the timestamps in each chunk's transcript text are absolute (video-wide), not chunk-relative. The code was clamping them against the chunk's own *length* instead of its *absolute end* (`offset + duration`), so for a later chunk basically every highlight got clamped down to an impossible range and thrown out. On top of that, `get_highlights` was then adding the offset a second time to whatever survived. Fixed the bound and removed the double-add — verified all 3 chunks of a 46min video now return highlights.

**2. Output clips are basically unplayable outside a local file browser.**
The final mux step re-encodes with `-c:v copy`, which just passes through whatever `cv2.VideoWriter` wrote — and its `mp4v` fourcc is old-school MPEG-4 Part 2. Most modern players (I tried sending clips through Telegram) won't render that inline. Switched the mux to re-encode to H.264.

**3. Cropping crashed (segfault) partway through a clip.**
`writer.write()` was being fed `frame[y0:y0+h, x0:x0+w]` directly — a non-contiguous numpy view — which corrupts memory and crashes a variable number of frames in. Wrapped it in `np.ascontiguousarray`.

**Also, smaller stuff while I was in there:**
- Bumped `max_output_tokens` for the Gemini local LLM call (8192 → 24576) — the 3.x "thinking" models spend part of the budget on hidden reasoning tokens before the actual JSON, and 8192 wasn't enough headroom for some chunks.
- Pinned `opencv-python<5` in `requirements-local.txt` — 5.x dropped `cv2.CascadeClassifier`, which the face-tracking crop needs, so a fresh install currently crashes immediately.
- Face detection now runs every 5th frame at 1/4 resolution instead of every frame at full res (~5x faster reframing; the existing smoothing already hides the coarser cadence).
- `_cut_subclip` now seeks before `-i` instead of after, so trimming a clip near the end of a long source doesn't decode the entire file up to that point first.

Tested end-to-end: 46-minute source video, `--num-clips 10`, all 10 clips came out with correct timestamps and play fine in QuickTime/VLC/Telegram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEn2jBricQW66qXBj1EeVb